### PR TITLE
Optional comma separated list of roles provided during user creation

### DIFF
--- a/public/js/adminMongo.js
+++ b/public/js/adminMongo.js
@@ -148,7 +148,11 @@ $(document).ready(function() {
         $.ajax({
             method: "POST",
             url: "/" + $("#conn_name").val() + "/" + $("#db_name").val() + "/" + $("#coll_name").val() + "/user_create",
-            data: {"username": $("#new_username").val(), "user_password": $("#new_password").val()}
+                data: {
+                    "username": $("#new_username").val(),
+                    "user_password": $("#new_password").val(),
+                    "roles_text": $("#new_user_roles").val()
+                }
         })
         .success(function(msg) {
             show_notification(msg,"success");

--- a/routes/index.js
+++ b/routes/index.js
@@ -438,9 +438,10 @@ router.post('/:conn/:db/:coll/user_create', function (req, res, next) {
             res.end('Error connecting to database: ' + err);
         }else{
             var db = mongojs(mongo_db.db(req.params.db));
-            
+            var roles = req.body.roles_text ? req.body.roles_text.split(/\s*,\s*/) : [];
+
             // Add a user
-            db.addUser({"user": req.body.username, "pwd": req.body.user_password, "roles": []}, function (err, user_name) {
+            db.addUser({"user": req.body.username, "pwd": req.body.user_password, "roles": roles}, function (err, user_name) {
                 if(err){
                     console.error('Error creating user: ' + err);
                     res.writeHead(400, { 'Content-Type': 'application/text' }); 

--- a/views/db.hbs
+++ b/views/db.hbs
@@ -27,7 +27,9 @@
 			<label for="new_pasword">User Password</label>
 			<input type="password" class="form-control input-sm" id="new_password" placeholder="Password"><br/>
 			<label for="new_password_confirm">Confirm password</label>
-			<input type="password" class="form-control input-sm" id="new_password_confirm" placeholder="Confirm">
+			<input type="password" class="form-control input-sm" id="new_password_confirm" placeholder="Confirm"><br/>
+            <label for="new_user_roles">Roles</label>
+            <input type="text" class="form-control input-sm" id="new_user_roles" placeholder="Optional: comma separated user roles"><br/>
 			</br>
 			<button class="btn btn-success btn-sm pull-right" id="user_create">Create user</button>
 			</br></br>


### PR DESCRIPTION
Hi!

Added optional field for specifying list of roles during creating users.

In terms of MongoDB commands it looks like this:
```
db.createUser({
    user: "myReader",
    pwd: "reader",
    roles: [ "read" ]
  });
```
Currently this command grants given roles only in **current** database. MongoDB supports also cross-database roles (an idea for future).

Thanks!