### PR TITLE
Work with number types for _id.

### DIFF
--- a/public/js/pagination.js
+++ b/public/js/pagination.js
@@ -43,7 +43,7 @@ $(document).ready(function() {
         for (var i = 0; i < data.length; i++) {
             var inner_html = '<div class="col-xs-12 col-md-8 col-lg-10 no-pad-left"><pre class="code-block doc_view"><code class="json">' + JSON.stringify(data[i]) + '</code></pre></div>';
             inner_html += '<div class="col-xs-6 col-md-2 col-lg-1 text-left pad-bottom"><a href="#"  class="btn btn-danger btn-sm" onclick="deleteDoc(\''+data[i]._id+'\')" style="margin-right: 15px; margin-left: 15px;">Delete</a></div>';
-            inner_html += '<div class="col-xs-6 col-md-2 col-lg-1 text-right pad-bottom"><a href="/'+ conn_name +"/" + db_name + "/" + coll_name + "/edit/" + data[i]._id+'" class="btn btn-success btn-sm">Edit</a></div>';
+            inner_html += '<div class="col-xs-6 col-md-2 col-lg-1 text-right pad-bottom"><a href="/'+ conn_name +"/" + db_name + "/" + coll_name + "/edit/" + data[i]._id+'?type=' + typeof data[i]._id + '" class="btn btn-success btn-sm">Edits</a></div>';
             $('#coll_docs').append(inner_html);
         };
         

--- a/routes/index.js
+++ b/routes/index.js
@@ -858,7 +858,7 @@ router.post('/:conn/:db/:coll/edit_doc', function (req, res, next) {
             // remove the _id form the body object so we set in query
             var doc_id = req.body['_id'];
             delete req.body['_id'];
-            db.collection(req.params.coll).update({_id: parse_doc_id(doc_id)},req.body, function (err, doc, lastErrorObject) {
+            db.collection(req.params.coll).update({_id: parse_doc_id(doc_id, typeof doc_id)},req.body, function (err, doc, lastErrorObject) {
                 if(err){
                     console.error("Error updating document: " + err);
                     res.writeHead(400, { 'Content-Type': 'application/text' });
@@ -1280,10 +1280,10 @@ function render_error(res, req, err, conn){
 // we need to check the type directly from the field.
 function parse_doc_id(value, type){
     var ObjectID = require('mongodb').ObjectID;
-    if(ObjectID.isValid(value) == true){
-        return new ObjectID(value);
-    }else if (type === 'number'){
+    if (type === 'number'){
        return parseInt(value);
+    }else if(ObjectID.isValid(value)){
+        return new ObjectID(value);
     }else{
         return value;
     }

--- a/routes/index.js
+++ b/routes/index.js
@@ -399,7 +399,8 @@ router.get('/:conn/:db/:coll/edit/:doc_id', function (req, res, next) {
 
             db.getCollectionNames(function (err, collection_list) {
                 get_sidebar_list(mongo_db, uri.database, function(err, sidebar_list) {
-                    db.collection(req.params.coll).findOne({_id: parse_doc_id(req.params.doc_id)}, function(err, coll_doc) {
+                    var id = parse_doc_id(req.params.doc_id, req.query.type);
+                    db.collection(req.params.coll).findOne({_id: id}, function(err, coll_doc) {
                         if (collection_list.indexOf(req.params.coll) === -1) {
                             console.error("No collection found");
                             render_error(res, req, "Collection does not exist", req.params.conn);
@@ -1273,24 +1274,19 @@ function render_error(res, req, err, conn){
 // Some MongoDB's are going to have _id fields which are not
 // MongoDB ObjectID's. In cases like this, we cannot cast all _id
 // as a ObjectID in the query. We can run a ObjectID.isValid() check
-// to determine whether it is an ObjectID (most likely), then we check
-// if we can parse it as an integer (second most likely), then we check
-// for a string. Is someone has a better way of doing this (I'm sure someone does)
-// please submit fix and submit a pull request.
-function parse_doc_id(value){
+// to determine whether it is an ObjectID.
+//
+// All params come as string type, so for other cases
+// we need to check the type directly from the field.
+function parse_doc_id(value, type){
     var ObjectID = require('mongodb').ObjectID;
     if(ObjectID.isValid(value) == true){
         return new ObjectID(value);
-    }else if (isInt(value) == true){
+    }else if (type === 'number'){
        return parseInt(value);
     }else{
         return value;
     }
-}
-
-// check if is int
-function isInt(value) {
-  return !isNaN(value) && (function(x) { return (x | 0) === x; })(parseFloat(value))
 }
 
 // only want the first 9 stats


### PR DESCRIPTION
The previous `isInt` function didn't work, and you could not edit documents with `typeof _id === 'number'`.
This fixes that edit issue only.