### PR TITLE
Break words in links that are too long for column

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -68,6 +68,11 @@ body {
     margin-bottom: 15px;
 }
 
+.list-group-item a {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
 .db_link{
     color: #2c3e50;
 }
@@ -108,4 +113,3 @@ body {
 .notify_message-danger{
     background-color: #e74c3c;
 }
-


### PR DESCRIPTION
The overflow on long names were causing it to flow out of the column. This change break's the word even if there is no valid breakpoint.

More work needs to be done to get the icon fixed, but this at least keeps things in their proper columns.


**Before:**
![screen shot 2016-02-11 at 5 11 16 pm](https://cloud.githubusercontent.com/assets/808425/12996295/68012530-d0e3-11e5-845f-4d521ff17fca.png)

**After:**
![screen shot 2016-02-11 at 5 12 16 pm](https://cloud.githubusercontent.com/assets/808425/12996303/75e6c3b2-d0e3-11e5-9451-1181d55ca98d.png)
