### PR TITLE
Added environment variables for use in docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,17 +93,20 @@ adminMongo will listen on host: `localhost` and  port: `1234` by default. This c
 
 > Note: Any changes to the config file requires a restart of the application
 
+All above parameters are usable through the environment which makes it very handy to when using adminMongo as a docker container!
+just run `docker run -e HOST=yourchoice -e PORT=1234 ...`
+
 The config file (optional) options are:
 
-|Option|Definition|
-|--- |--- |
-|`host`|The IP address  `adminMongo`  will listen on|
-|`port`|The Port `adminMongo` will listen on|
-|`docs_per_page`|When viewing docs you can specify how many are shown per page|
-|`password`|An application level password to add simply authentication|
-|`locale`|The locale is automatically set to the detected locale of Nodejs. If there is not a translation, `adminMongo` will default to English. This setting overrides the default/detected value|
-|`context`|Setting a `context` of "dbApp" is like changing the base URL of the app and will mean the app will listen on `http://10.0.0.1:4321/dbApp`. Ommiting a context will mean the application will listen on root. Eg: `http://10.0.0.1:4321`. This setting can be useful when running `adminMongo` behind Nginx etc.|
-|`monitoring`|Whether to run monitoring at regular intervals. Defaults to true or on|
+|Option|Env-variable|Definition|
+|--- |--- |--- |
+|`host`|`HOST`|The IP address  `adminMongo`  will listen on|
+|`port`|`PORT`|The Port `adminMongo` will listen on|
+|`docs_per_page`|`DOCS_PER_PAGE`|When viewing docs you can specify how many are shown per page|
+|`password`|`PASSWORD`|An application level password to add simply authentication|
+|`locale`|`LOCALE`|The locale is automatically set to the detected locale of Nodejs. If there is not a translation, `adminMongo` will default to English. This setting overrides the default/detected value|
+|`context`|`CONTEXT`|Setting a `context` of "dbApp" is like changing the base URL of the app and will mean the app will listen on `http://10.0.0.1:4321/dbApp`. Ommiting a context will mean the application will listen on root. Eg: `http://10.0.0.1:4321`. This setting can be useful when running `adminMongo` behind Nginx etc.|
+|`monitoring`|`MONITORING`|Whether to run monitoring at regular intervals. Defaults to true or on|
 
 ### Setting a context path
 
@@ -162,6 +165,15 @@ For example:
 ```
 
 Note: The connection can be either local or remote hosted on VPS or MongoDB service such as mLab.
+
+The connection can also be automatically initiated through the environment (or with the docker -e parameters)
+|Env-variable|Description|
+|--- |--- |
+|`CONN_NAME`|The name of the connection to create on boot|
+|`DB_USERNAME`|The username for the database connection|
+|`DB_PASSWORD`|The password fot the database user|
+|`DB_HOST`|The host IP address or DNS name without the port!|
+|`DB_PORT`|The port of the mongoDB database, if not provided the default 27017 will be used|
 
 *The Connection setup screen*
 ![adminMongo connections screen](https://raw.githubusercontent.com/mrvautin/mrvautin.github.io/master/images/adminMongo/adminMongo_connections.png "adminMongo connections screen")

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ For example:
 Note: The connection can be either local or remote hosted on VPS or MongoDB service such as mLab.
 
 The connection can also be automatically initiated through the environment (or with the docker -e parameters)
+
 |Env-variable|Description|
 |--- |--- |
 |`CONN_NAME`|The name of the connection to create on boot|

--- a/app.js
+++ b/app.js
@@ -88,8 +88,35 @@ var config_app = path.join(dir_config, 'app.json');
 
 // Check existence of config dir and config files, create if nothing
 if(!fs.existsSync(dir_config)) fs.mkdirSync(dir_config);
-if(!fs.existsSync(config_connections)) fs.writeFileSync(config_connections, '{}');
-if(!fs.existsSync(config_app)) fs.writeFileSync(config_app, '{}');
+
+
+//The base of the /config/app.json file, will check against environment values
+var configApp = {
+    app: {}
+};
+if (process.env.HOST) configApp.app.host = process.env.HOST;
+if (process.env.PORT) configApp.app.port = process.env.PORT;
+if (process.env.DOCS_PER_PAGE) configApp.app.docs_per_page = process.env.DOCS_PER_PAGE;
+if (process.env.PASSWORD) configApp.app.password = process.env.PASSWORD;
+if (process.env.LOCALE) configApp.app.locale = process.env.LOCALE;
+if (process.env.CONTEXT) configApp.app.locale = process.env.CONTEXT;
+if (process.env.MONITORING) configApp.app.monitoring = process.env.MONITORING;
+
+if(!fs.existsSync(config_app)) fs.writeFileSync(config_app, JSON.stringify(configApp));
+
+//Check the env for a connection to initiate
+var configConnection = {
+    connections: {}
+};
+if (process.env.CONN_NAME && process.env.DB_USERNAME && process.env.DB_PASSWORD && process.env.DB_HOST) {
+    if (!process.env.DB_PORT) process.env.DB_PORT = '27017'; //Use the default mongodb port when DB_PORT is not set
+    configConnection.connections[process.env.CONN_NAME] = {
+        connection_options: {},
+        connection_string: "mongodb://" + process.env.DB_USERNAME + ':' + process.env.DB_PASSWORD + '@' + process.env.DB_HOST + ':' + process.env.DB_PORT
+    }
+}
+
+if(!fs.existsSync(config_connections)) fs.writeFileSync(config_connections, JSON.stringify(configConnection));
 
 // if config files exist but are blank we write blank files for nconf
 if(fs.existsSync(config_app, 'utf8')){
@@ -107,6 +134,7 @@ if(fs.existsSync(config_connections, 'utf8')){
 // holds the mongoDB connections
 nconf.add('connections', {type: 'file', file: config_connections});
 nconf.add('app', {type: 'file', file: config_app});
+
 
 // set app defaults
 var app_host = '0.0.0.0';

--- a/routes/config.js
+++ b/routes/config.js
@@ -15,6 +15,8 @@ router.post('/config/add_config', function (req, res, next){
     var connPool = require('../connections');
     var connection_list = req.nconf.connections.get('connections');
 
+
+
     // check if name already exists
     if(connection_list !== undefined){
         if(connection_list[req.body[0]] !== undefined){


### PR DESCRIPTION
Hello,

I created the support to run mongoAdmin through a docker container with multiple -e options.
e.g.:
docker run -d --name adminMongo -e CONN_NAME=test -e DB_USERNAME=someuser -e DB_PASSWORD=somepass -e DB_HOST=172.17.0.2 -e PASSWORD=something mrvautin/adminmongo

Fully tested & updated README

Hope it helps for some of your users!

Best regards,

Hacor
