### PR TITLE
add 64-bit arch to build to fix white screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "find ./tests -name '*.js' | xargs mocha -R spec -t 5000",
     "packageOsx": "electron-packager ./ adminMongo --out=releases/ --platform=darwin --arch=x64 --prune --overwrite --ignore=releases/* --icon=public/logo.icns",
     "packageWin32": "electron-packager ./ adminMongo --out=releases/ --platform=win32 --arch=ia32 --prune --overwrite --ignore=releases/* --icon=public/logo.ico",
+    "packageWin64": "electron-packager ./ adminMongo --out=releases/ --platform=win32 --arch=x64 --prune --overwrite --ignore=releases/* --icon=public/logo.ico",
     "packageLinux": "electron-packager ./ adminMongo --out=releases/ --platform=linux --arch=ia32 --prune --overwrite --ignore=releases/* --icon=public/logo.ico"
   },
   "keywords": [


### PR DESCRIPTION
I only get a white screen when I open either the 32-bit version or 64-bit version that I build from source. I thought it could be related to [this](https://github.com/electron/electron/issues/7049) which is why I compiled a 64-bit version. I thought you might include my work, in case someone else may want it.