### PR TITLE
Removed empty config from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM node:latest
 
 COPY . /app/user
 
+# Remove the standard app.json config - see issue #152 for details
+RUN rm /app/user/config/app.json
+
 WORKDIR /app/user
-
 RUN npm install
-
 CMD node app.js


### PR DESCRIPTION
Allows ENV variables (such as CONTEXT) to be used.