### PR TITLE
Delete config.json and expose port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,8 @@ COPY package.json .
 RUN npm install --production
 
 COPY . .
+RUN rm /app/user/config/config.json
+
+EXPOSE 1234
+
 CMD node app.js


### PR DESCRIPTION
If the config.json exists, the environment variables have no effect at all.

Furthermore, if the port is not properly exposed, jwilder/nginx-proxy will not be able to catch the container.