### PR TITLE
0.0.0.0 and localhost is different

### DIFF
--- a/app.js
+++ b/app.js
@@ -147,7 +147,7 @@ nconf.add('connections', {type: 'file', file: config_connections});
 nconf.add('app', {type: 'file', file: config_app});
 
 // set app defaults
-var app_host = process.env.HOST || '0.0.0.0';
+var app_host = process.env.HOST || 'localhost';
 var app_port = process.env.PORT || 1234;
 
 // get the app configs and override if present


### PR DESCRIPTION
better to listen by default on `localhost` instead of `0.0.0.0` as `0.0.0.0` will listen on all available network interface not only local one