### PR TITLE
Update public/js/adminMongo.js fix Regular match failed

### DIFF
--- a/public/js/adminMongo.js
+++ b/public/js/adminMongo.js
@@ -110,7 +110,7 @@ $(document).ready(function(){
                 val = parseInt(val);
             }else{
             // if we find an integer wrapped in quotes
-                var strIntReg = new RegExp('^"[0-9]"+$');
+                var strIntReg = new RegExp('^"[0-9]+"$');
                 if(val.match(strIntReg)){
                     val = val.replace(/"/g, '');
                 }


### PR DESCRIPTION
fix the value of an integer string cannot be queried.
^"[0-9]"+$ cannot match "123"
^"[0-9]+"$ can match "123"