### PR TITLE
add Dockerfile for Raspberry Pi

### DIFF
--- a/Dockerfile_pi
+++ b/Dockerfile_pi
@@ -1,0 +1,8 @@
+FROM resin/raspberry-pi-alpine-node:8-slim
+WORKDIR /app/user
+
+COPY package.json .
+RUN npm install --production
+
+COPY . .
+CMD node app.js


### PR DESCRIPTION
I just added a Dockerfiler that allows to have a raspberry pi container. To create the image:

`docker build -t mrvautin/adminmongo-rpi -f Dockerfile_pi .`

Let me know if that clear enough and/or should I add something to the README.md as well.

I tested with a PI2 and worked great. The generated image is around 150MB. Probably can be trimmed down.