### PR TITLE
Simplify connection string from ENV

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,19 +111,10 @@ if(!fs.existsSync(config_app)) fs.writeFileSync(config_app, JSON.stringify(confi
 var configConnection = {
     connections: {}
 };
-if(process.env.CONN_NAME && process.env.DB_HOST) {
-    if(!process.env.DB_PORT) process.env.DB_PORT = '27017'; // Use the default mongodb port when DB_PORT is not set
-    var connectionString = 'mongodb://';
-    if(process.env.DB_USERNAME && process.env.DB_PASSWORD && process.env.DB_NAME) {
-        connectionString += process.env.DB_USERNAME + ':' + process.env.DB_PASSWORD + '@' + process.env.DB_HOST + ':' + process.env.DB_PORT + '/' + process.env.DB_NAME;
-    }else if (process.env.DB_USERNAME && process.env.DB_PASSWORD) {
-        connectionString += process.env.DB_USERNAME + ':' + process.env.DB_PASSWORD + '@' + process.env.DB_HOST + ':' + process.env.DB_PORT + '/'
-    } else {    
-        connectionString += process.env.DB_HOST + ':' + process.env.DB_PORT
-    }
+if(process.env.CONN_NAME && process.env.CONN_URI) {
     configConnection.connections[process.env.CONN_NAME] = {
-        connection_options: {},
-        connection_string: connectionString
+        connection_options: process.env.CONN_OPTS,
+        connection_string: process.env.CONN_URI
     };
 }
 if (!fs.existsSync(config_connections) || fs.readFileSync(config_connections, 'utf8') === '{}')


### PR DESCRIPTION
Make connection string come as is from ENV to simplify it and allow flexibility as well as adding connection options