### PR TITLE
Fix: Test errors, Removes Node 4.0.0, 4.4.5 from testing and Fix: new user creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 services:
   - mongodb
 node_js:
-  - "4.0.0"
-  - "4.4.5"
+  - "4.5.0"
   - "5.4.1"
   - "6.2"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-standard": "^2.0.0",
     "jsdom": "^9.4.1",
     "mocha": "^2.5.3",
-    "mocha-jsdom": "^1.1.0",
+    "mocha-jsdom": "~1.1.0",
     "supertest": "^1.2.0"
   }
 }

--- a/routes/users.js
+++ b/routes/users.js
@@ -29,7 +29,7 @@ router.post('/users/:conn/:db/user_create', function (req, res, next){
     var roles = req.body.roles_text ? req.body.roles_text.split(/\s*,\s*/) : [];
 
     // Add a user
-    mongo_db.addUser(req.body.username, req.body.user_password, {'roles': roles}, function (err, user_name){
+    mongo_db.command({ createUser: req.body.username,  pwd: req.body.user_password, 'roles': roles }, function (err, user_name){
         if(err){
             console.error('Error creating user: ' + err);
             res.status(400).json({'msg': req.i18n.__('Error creating user') + ': ' + err});


### PR DESCRIPTION

**Fixes:** `Document tests` suits error: Cannot find module 'jsdom/lib/old-api'

**Fixes:** new user creation #219

**Removes Node 4.0.0, 4.4.5 from the testing matrix:**
**mongodb-extended-json**'s dependency **bson** uses **Buffer.alloc** to convert $oid string to ObjectID which is available only staring with Node v.4.5.0
